### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are several ways to launch the game. Here is the simplest:
 
 1. Clone or download the repository
 2. Navigate to Astray's directory
-3. Start 'python -m SimpleHTTPServer' in your shell
+3. Start 'python -m SimpleHTTPServer' in your shell (for python 3.0 and above type 'python -m http.server' in your shell)
 4. Open 'localhost:8000' in your browser
 5. Enjoy!
 


### PR DESCRIPTION
For python 3.0 and above, 'python -m SimpleHTTPServer' doesn't work. The SimpleHTTPServer module has been merged into http.server in Python 3.