### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
                 ballMesh       = undefined,
                 ballRadius     = 0.25,
                 keyAxis        = [0, 0],
-                ironTexture    = THREE.ImageUtils.loadTexture('/ball.png'),
-                planeTexture   = THREE.ImageUtils.loadTexture('/concrete.png'),
-                brickTexture   = THREE.ImageUtils.loadTexture('/brick.png'),
+                ironTexture    = THREE.ImageUtils.loadTexture('ball.png'),
+                planeTexture   = THREE.ImageUtils.loadTexture('concrete.png'),
+                brickTexture   = THREE.ImageUtils.loadTexture('brick.png'),
                 gameState      = undefined,
 
             // Box2D shortcuts


### PR DESCRIPTION
image paths are accessed in the same directory and can not contain a leading directory separator.
tested on windows and Ubuntu